### PR TITLE
config: restrict nx release to core package only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@
 - create comprehensive README.md with detailed documentation ([d466536](https://github.com/kmakris23/store-sdk/commit/d466536))
 - Implement enhanced plugin architecture with event handler registration and include Angular example in CI builds ([fcf9ac3](https://github.com/kmakris23/store-sdk/commit/fcf9ac3))
 - enhance cart and order integration tests, improve error handling and assertions ([649641d](https://github.com/kmakris23/store-sdk/commit/649641d))
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ### 🩹 Fixes
 
 - **deps:** update angular monorepo to ~20.2.0 ([823cb86](https://github.com/kmakris23/store-sdk/commit/823cb86))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ### ❤️ Thank You
 

--- a/nx.json
+++ b/nx.json
@@ -2,10 +2,7 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "master",
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",
@@ -53,9 +50,7 @@
     }
   ],
   "release": {
-    "projects": [
-      "packages/core"
-    ],
+    "projects": ["packages/core"],
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true
@@ -74,9 +69,7 @@
   },
   "targetDefaults": {
     "test": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,10 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "master",
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",
@@ -17,7 +20,9 @@
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": { "targetName": "typecheck" },
+        "typecheck": {
+          "targetName": "typecheck"
+        },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -26,7 +31,12 @@
         }
       }
     },
-    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    },
     {
       "plugin": "@nx/vite/plugin",
       "options": {
@@ -43,13 +53,17 @@
     }
   ],
   "release": {
-    "projects": ["packages/*"],
+    "projects": [
+      "packages/core"
+    ],
     "version": {
       "preVersionCommand": "npx nx run-many -t build",
       "conventionalCommits": true
     },
     "changelog": {
-      "workspaceChangelog": { "createRelease": "github" },
+      "workspaceChangelog": {
+        "createRelease": "github"
+      },
       "projectChangelogs": {
         "renderOptions": {
           "authors": false,
@@ -58,5 +72,11 @@
       }
     }
   },
-  "targetDefaults": { "test": { "dependsOn": ["^build"] } }
+  "targetDefaults": {
+    "test": {
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13667,7 +13667,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -21865,7 +21864,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -23880,7 +23878,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -23963,12 +23960,48 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -24962,6 +24995,14 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/schema-utils": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
@@ -25290,7 +25331,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -25310,7 +25350,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -25327,7 +25366,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -25346,7 +25384,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### 🚀 Features
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 - enhance cart and order integration tests, improve error handling and assertions ([649641d](https://github.com/kmakris23/store-sdk/commit/649641d))
 - Implement enhanced plugin architecture with event handler registration and include Angular example in CI builds ([fcf9ac3](https://github.com/kmakris23/store-sdk/commit/fcf9ac3))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ## 1.3.5-alpha.5 (2025-09-10)
 

--- a/packages/hippoo/CHANGELOG.md
+++ b/packages/hippoo/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### 🚀 Features
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 - Implement enhanced plugin architecture with event handler registration and include Angular example in CI builds ([fcf9ac3](https://github.com/kmakris23/store-sdk/commit/fcf9ac3))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ## 1.3.5-alpha.5 (2025-09-10)
 

--- a/packages/jwt-authentication-for-wp-rest-api/CHANGELOG.md
+++ b/packages/jwt-authentication-for-wp-rest-api/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### 🚀 Features
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 - Implement enhanced plugin architecture with event handler registration and include Angular example in CI builds ([fcf9ac3](https://github.com/kmakris23/store-sdk/commit/fcf9ac3))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ## 1.3.5-alpha.5 (2025-09-10)
 

--- a/packages/simple-jwt-login/CHANGELOG.md
+++ b/packages/simple-jwt-login/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### 🚀 Features
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 - Implement enhanced plugin architecture with event handler registration and include Angular example in CI builds ([fcf9ac3](https://github.com/kmakris23/store-sdk/commit/fcf9ac3))
 
-### ⚠️  Breaking Changes
+### ⚠️ Breaking Changes
 
-- ⚠️  unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
+- ⚠️ unify authentication in core package and introduce WordPress plugin ([74ede26](https://github.com/kmakris23/store-sdk/commit/74ede26))
 
 ## 1.3.5-alpha.5 (2025-09-10)
 


### PR DESCRIPTION
- Update nx.json to only include packages/core in release configuration
- Remove other packages (hippoo, jwt-authentication-for-wp-rest-api, simple-jwt-login) from release pipeline
- This ensures only the main SDK package is versioned and published during releases