### PR TITLE
fix: update price_range schema to use ProductPriceRangeResponseSchema

### DIFF
--- a/packages/core/src/lib/types/store/product/product.price.response.ts
+++ b/packages/core/src/lib/types/store/product/product.price.response.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+export const ProductPriceRangeResponseSchema = z.looseObject({
+  min_amount: z.string(),
+  max_amount: z.string(),
+});
+
 export const ProductPriceResponseSchema = z.looseObject({
   currency_code: z.string(),
   currency_symbol: z.string(),
@@ -11,7 +16,7 @@ export const ProductPriceResponseSchema = z.looseObject({
   price: z.string(),
   regular_price: z.string(),
   sale_price: z.string(),
-  price_range: z.unknown(),
+  price_range: ProductPriceRangeResponseSchema.nullish(),
 });
 
 export type ProductPriceResponse = z.infer<typeof ProductPriceResponseSchema>;

--- a/packages/core/src/lib/types/store/product/product.price.response.ts
+++ b/packages/core/src/lib/types/store/product/product.price.response.ts
@@ -5,6 +5,10 @@ export const ProductPriceRangeResponseSchema = z.looseObject({
   max_amount: z.string(),
 });
 
+export type ProductPriceRangeResponse = z.infer<
+  typeof ProductPriceRangeResponseSchema
+>;
+
 export const ProductPriceResponseSchema = z.looseObject({
   currency_code: z.string(),
   currency_symbol: z.string(),


### PR DESCRIPTION
This pull request introduces a new schema for product price ranges and updates the product price response type to use this new schema. The changes improve type safety and data validation for product price ranges.

**Schema improvements:**

* Added a new `ProductPriceRangeResponseSchema` using `z.looseObject` to define `min_amount` and `max_amount` as string fields.
* Updated the `ProductPriceResponseSchema` to use the new `ProductPriceRangeResponseSchema` for the `price_range` field, allowing it to be `null` or undefined.