### PR TITLE
refactor(product): rename ProductQueryParams to AdminProductQueryPara…

### DIFF
--- a/packages/core/src/lib/services/admin/product.service.ts
+++ b/packages/core/src/lib/services/admin/product.service.ts
@@ -4,7 +4,7 @@ import { extractPagination } from '../../utilities/common.js';
 import * as qs from 'qs';
 import { ApiPaginationResult, ApiResult } from '../../types/api.js';
 import {
-  ProductQueryParams,
+  AdminProductQueryParams,
   AdminProduct,
   AdminProductRequest,
   AdminProductVariation,
@@ -25,11 +25,11 @@ export class AdminProductService extends BaseService {
    * List products
    */
   list(
-    params?: ProductQueryParams,
+    params?: AdminProductQueryParams,
     options?: RequestOptions
-  ): PaginatedRequest<AdminProduct[], ProductQueryParams> {
+  ): PaginatedRequest<AdminProduct[], AdminProductQueryParams> {
     const request = async (
-      pageParams?: ProductQueryParams
+      pageParams?: AdminProductQueryParams
     ): Promise<ApiPaginationResult<AdminProduct[]>> => {
       const query = pageParams
         ? qs.stringify(pageParams, { encode: false })
@@ -167,11 +167,11 @@ export class AdminProductService extends BaseService {
    */
   listVariations(
     productId: number,
-    params?: ProductQueryParams,
+    params?: AdminProductQueryParams,
     options?: RequestOptions
-  ): PaginatedRequest<AdminProductVariation[], ProductQueryParams> {
+  ): PaginatedRequest<AdminProductVariation[], AdminProductQueryParams> {
     const request = async (
-      pageParams?: ProductQueryParams
+      pageParams?: AdminProductQueryParams
     ): Promise<ApiPaginationResult<AdminProductVariation[]>> => {
       const query = pageParams
         ? qs.stringify(pageParams, { encode: false })

--- a/packages/core/src/lib/types/admin/product.types.ts
+++ b/packages/core/src/lib/types/admin/product.types.ts
@@ -306,7 +306,9 @@ export const AdminProductQueryParamsSchema = z.looseObject({
   exclude_meta: z.array(z.string()).optional(),
 });
 
-export type ProductQueryParams = z.infer<typeof AdminProductQueryParamsSchema>;
+export type AdminProductQueryParams = z.infer<
+  typeof AdminProductQueryParamsSchema
+>;
 
 /**
  * Query params for listing product custom-field names


### PR DESCRIPTION
This pull request updates the admin product service and related types to clarify and standardize the naming of product query parameters. The main change is renaming the `ProductQueryParams` type to `AdminProductQueryParams` throughout the admin product service, which improves clarity and reduces confusion between admin and non-admin product queries.

**Type and API parameter renaming:**

* Renamed the `ProductQueryParams` type to `AdminProductQueryParams` in `product.types.ts` and updated all usages in the admin product service methods (`list` and `listVariations`) to use the new type name for improved clarity and consistency. [[1]](diffhunk://#diff-84a49b9cf6d22d9a4f5703b7fa5cf484a80a8f92b9fe8c12b039f4a901035263L7-R7) [[2]](diffhunk://#diff-84a49b9cf6d22d9a4f5703b7fa5cf484a80a8f92b9fe8c12b039f4a901035263L28-R32) [[3]](diffhunk://#diff-84a49b9cf6d22d9a4f5703b7fa5cf484a80a8f92b9fe8c12b039f4a901035263L170-R174) [[4]](diffhunk://#diff-6724b7d1aff4d691c8747fda9130cf816541130f111e9758e680a707c10639f4L309-R311)…ms for consistency